### PR TITLE
celestia: pass submit options

### DIFF
--- a/celestia/celestia.go
+++ b/celestia/celestia.go
@@ -74,12 +74,17 @@ func (c *CelestiaDA) Commit(daBlobs []da.Blob) ([]da.Commitment, error) {
 }
 
 // Submit submits the Blobs to Data Availability layer.
-func (c *CelestiaDA) Submit(daBlobs []da.Blob) ([]da.ID, []da.Proof, error) {
+func (c *CelestiaDA) Submit(daBlobs []da.Blob, daOptions *da.SubmitOptions) ([]da.ID, []da.Proof, error) {
 	blobs, commitments, err := c.blobsAndCommitments(daBlobs)
 	if err != nil {
 		return nil, nil, err
 	}
-	height, err := c.client.Blob.Submit(c.ctx, blobs, blob.DefaultSubmitOptions())
+	blobOptions := blob.DefaultSubmitOptions()
+	if daOptions != nil {
+		blobOptions.Fee = daOptions.Fee
+		blobOptions.GasLimit = daOptions.Gas
+	}
+	height, err := c.client.Blob.Submit(c.ctx, blobs, blobOptions)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/celestia/celestia_test.go
+++ b/celestia/celestia_test.go
@@ -79,7 +79,7 @@ func TestCelestiaDA(t *testing.T) {
 	})
 
 	t.Run("Submit_empty", func(t *testing.T) {
-		blobs, proofs, err := m.Submit(nil)
+		blobs, proofs, err := m.Submit(nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(blobs))
 		assert.Equal(t, 0, len(proofs))
@@ -118,7 +118,7 @@ func TestCelestiaDA(t *testing.T) {
 	})
 
 	t.Run("Submit_existing", func(t *testing.T) {
-		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}})
+		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(blobs))
 		assert.Equal(t, 1, len(proofs))

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -45,7 +45,7 @@ func (t *TestSuite) SetupSuite() {
 	}
 
 	// pulls an image, creates a container based on it and runs it
-	resource, err := pool.Run("ghcr.io/rollkit/local-celestia-devnet", "4ecd750", []string{})
+	resource, err := pool.Run("ghcr.io/rollkit/local-celestia-devnet", "0dd21fb", []string{})
 	if err != nil {
 		t.Failf("Could not start resource", "error: %v\n", err)
 	}
@@ -75,12 +75,12 @@ func (t *TestSuite) SetupSuite() {
 	buf := new(bytes.Buffer)
 	opts.StdOut = buf
 	opts.StdErr = buf
-	_, err = resource.Exec([]string{"/bin/celestia", "bridge", "auth", "admin", "--node.store", "/home/celestia/bridge"}, opts)
+	_, err = resource.Exec([]string{"/bin/celestia-da", "bridge", "auth", "admin", "--node.store", "/home/celestia/bridge"}, opts)
 	if err != nil {
 		t.Failf("Could not execute command", "error: %v\n", err)
 	}
 
-	t.token = buf.String()
+	t.token = strings.TrimSpace(buf.String())
 }
 
 func (t *TestSuite) TearDownSuite() {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/rollkit/go-da v0.0.0-20231225164956-a3533025ce47
+	github.com/rollkit/go-da v0.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -2102,8 +2102,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rollkit/go-da v0.0.0-20231225164956-a3533025ce47 h1:aprTK4O2aqZ/Mb1pqrxH6EdKs331oJEyf5OROpN1o1Q=
-github.com/rollkit/go-da v0.0.0-20231225164956-a3533025ce47/go.mod h1:cy1LA9kCyCJHgszKkTh9hJn816l5Oa87GMA2c1imfqA=
+github.com/rollkit/go-da v0.0.1 h1:dfm4Qojsg7AvxiJvrjJbZkXp+1BY/3GfLTIgz29E23U=
+github.com/rollkit/go-da v0.0.1/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=


### PR DESCRIPTION
## Overview

This PR updates go-da to v0.0.1 which includes a breaking change in the DA interface.

The `Submit` method now accepts a second param: `SubmitOptions`, which can be `nil` to default to `DefaultSubmitOptions` as before. `SubmitOptions` which is non-nil and includes `Gas` and `Fee` params will be passed through to the node.

This PR adds `SubmitOptions` to the `Submit` method.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords

Depends on:

- #32 
- https://github.com/rollkit/go-da/pull/27
- https://github.com/rollkit/local-celestia-devnet/pull/82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `Submit` function to accept transaction fee and gas limit options.

- **Refactor**
  - Updated test suite setup with a new container image tag and command adjustments.
  - Improved test case configurations to align with the updated `Submit` function parameters.

- **Bug Fixes**
  - Fixed an issue where token strings could have leading or trailing white spaces in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->