### PR TITLE
ci: update test for celestia-da

### DIFF
--- a/celestia_test.go
+++ b/celestia_test.go
@@ -54,7 +54,7 @@ func (t *TestSuite) SetupSuite() {
 	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
 	pool.MaxWait = 60 * time.Second
 	if err := pool.Retry(func() error {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/header/1", resource.GetPort("26659/tcp")))
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/header/10", resource.GetPort("26659/tcp")))
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func (t *TestSuite) SetupSuite() {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(string(bz), "error") {
+		if strings.Contains(string(bz), "header: given height is from the future") {
 			return errors.New(string(bz))
 		}
 		return nil

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -71,6 +71,9 @@ func (t *TestSuite) SetupSuite() {
 		log.Fatalf("Could not start local-celestia-devnet: %s", err)
 	}
 
+	// wait a bit more
+	time.Sleep(time.Second)
+
 	opts := dockertest.ExecOptions{}
 	buf := new(bytes.Buffer)
 	opts.StdOut = buf

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -75,12 +75,12 @@ func (t *TestSuite) SetupSuite() {
 	buf := new(bytes.Buffer)
 	opts.StdOut = buf
 	opts.StdErr = buf
-	_, err = resource.Exec([]string{"/bin/celestia", "bridge", "auth", "admin", "--node.store", "/home/celestia/bridge"}, opts)
+	_, err = resource.Exec([]string{"/bin/celestia-da", "bridge", "auth", "admin", "--node.store", "/home/celestia/bridge"}, opts)
 	if err != nil {
 		t.Failf("Could not execute command", "error: %v\n", err)
 	}
 
-	t.token = buf.String()
+	t.token = strings.TrimSpace(buf.String())
 }
 
 func (t *TestSuite) TearDownSuite() {

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -45,7 +45,7 @@ func (t *TestSuite) SetupSuite() {
 	}
 
 	// pulls an image, creates a container based on it and runs it
-	resource, err := pool.Run("ghcr.io/rollkit/local-celestia-devnet", "4ecd750", []string{})
+	resource, err := pool.Run("ghcr.io/rollkit/local-celestia-devnet", "v0.12.2", []string{})
 	if err != nil {
 		t.Failf("Could not start resource", "error: %v\n", err)
 	}

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -45,7 +45,7 @@ func (t *TestSuite) SetupSuite() {
 	}
 
 	// pulls an image, creates a container based on it and runs it
-	resource, err := pool.Run("ghcr.io/rollkit/local-celestia-devnet", "v0.12.2", []string{})
+	resource, err := pool.Run("ghcr.io/rollkit/local-celestia-devnet", "v0.12.5", []string{})
 	if err != nil {
 		t.Failf("Could not start resource", "error: %v\n", err)
 	}

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -54,7 +54,7 @@ func (t *TestSuite) SetupSuite() {
 	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
 	pool.MaxWait = 60 * time.Second
 	if err := pool.Retry(func() error {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/balance", resource.GetPort("26659/tcp")))
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/header/1", resource.GetPort("26659/tcp")))
 		if err != nil {
 			return err
 		}
@@ -70,9 +70,6 @@ func (t *TestSuite) SetupSuite() {
 	}); err != nil {
 		log.Fatalf("Could not start local-celestia-devnet: %s", err)
 	}
-
-	// wait a bit more
-	time.Sleep(time.Second)
 
 	opts := dockertest.ExecOptions{}
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
## Overview

This PR fixes an issue with the test suite where the auth token was not being passed correctly, also updates test suite to use `celestia-da` instead of `celestia`.

The tests were failing due to:

    header: given height is from the future: networkHeight: 1, requestedHeight: 4

so replaced the `/balance` check with `/header/10`

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Updated the setup process for test suites to use `celestia-da` command, ensuring cleaner token handling.
	- Modified the commands for starting a container, retrieving data, and executing commands within the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->