### PR TITLE
da: replace submit options with gas price

### DIFF
--- a/celestia/celestia.go
+++ b/celestia/celestia.go
@@ -83,7 +83,7 @@ func (c *CelestiaDA) Submit(daBlobs []da.Blob, gasPrice float64) ([]da.ID, []da.
 		return nil, nil, err
 	}
 	options := blob.DefaultSubmitOptions()
-	if gasPrice != 0 {
+	if gasPrice >= 0 {
 		blobSizes := make([]uint32, len(blobs))
 		for i, blob := range blobs {
 			blobSizes[i] = uint32(len(blob.Data))

--- a/celestia/celestia_test.go
+++ b/celestia/celestia_test.go
@@ -79,7 +79,7 @@ func TestCelestiaDA(t *testing.T) {
 	})
 
 	t.Run("Submit_empty", func(t *testing.T) {
-		blobs, proofs, err := m.Submit(nil)
+		blobs, proofs, err := m.Submit(nil, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(blobs))
 		assert.Equal(t, 0, len(proofs))
@@ -118,7 +118,7 @@ func TestCelestiaDA(t *testing.T) {
 	})
 
 	t.Run("Submit_existing", func(t *testing.T) {
-		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}})
+		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(blobs))
 		assert.Equal(t, 1, len(proofs))

--- a/celestia/celestia_test.go
+++ b/celestia/celestia_test.go
@@ -79,7 +79,7 @@ func TestCelestiaDA(t *testing.T) {
 	})
 
 	t.Run("Submit_empty", func(t *testing.T) {
-		blobs, proofs, err := m.Submit(nil, 0)
+		blobs, proofs, err := m.Submit(nil, -1)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(blobs))
 		assert.Equal(t, 0, len(proofs))
@@ -118,7 +118,7 @@ func TestCelestiaDA(t *testing.T) {
 	})
 
 	t.Run("Submit_existing", func(t *testing.T) {
-		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, 0)
+		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, -1)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(blobs))
 		assert.Equal(t, 1, len(proofs))

--- a/celestia/celestia_test.go
+++ b/celestia/celestia_test.go
@@ -124,6 +124,13 @@ func TestCelestiaDA(t *testing.T) {
 		assert.Equal(t, 1, len(proofs))
 	})
 
+	t.Run("Submit_existing_with_gasprice", func(t *testing.T) {
+		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, 0.5)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(blobs))
+		assert.Equal(t, 1, len(proofs))
+	})
+
 	t.Run("Validate_existing", func(t *testing.T) {
 		commitment, err := hex.DecodeString("1b454951cd722b2cf7be5b04554b76ccf48f65a7ad6af45055006994ce70fd9d")
 		assert.NoError(t, err)

--- a/celestia/mock.go
+++ b/celestia/mock.go
@@ -17,7 +17,7 @@ type MockBlobAPI struct {
 }
 
 // Submit mocks the blob.Submit method
-func (m *MockBlobAPI) Submit(context.Context, []*blob.Blob, *blob.SubmitOptions) (uint64, error) {
+func (m *MockBlobAPI) Submit(ctx context.Context, blobs []*blob.Blob, options *blob.SubmitOptions) (uint64, error) {
 	m.height += 1
 	return m.height, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -350,3 +350,5 @@ replace (
 	github.com/filecoin-project/dagstore => github.com/celestiaorg/dagstore v0.0.0-20230824094345-537c012aa403
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.29.0-tm-v0.34.29
 )
+
+replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.0.2-0.20240109212456-5258ae15192c

--- a/go.mod
+++ b/go.mod
@@ -351,4 +351,4 @@ replace (
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.29.0-tm-v0.34.29
 )
 
-replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.0.2-0.20240109212456-5258ae15192c
+replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.0.2-0.20240109213634-1bddfc5ae4fb

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/rollkit/go-da v0.0.0-20231225164956-a3533025ce47
+	github.com/rollkit/go-da v0.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
@@ -350,5 +350,3 @@ replace (
 	github.com/filecoin-project/dagstore => github.com/celestiaorg/dagstore v0.0.0-20230824094345-537c012aa403
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.29.0-tm-v0.34.29
 )
-
-replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.0.2-0.20240109232900-0707fa92070b

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/celestiaorg/celestia-app v1.6.0
 	github.com/celestiaorg/celestia-node v0.12.2
 	github.com/celestiaorg/nmt v0.20.0
+	github.com/cosmos/cosmos-sdk v0.46.14
 	github.com/cristalhq/jwt v1.2.0
 	github.com/filecoin-project/go-jsonrpc v0.3.1
 	github.com/ipfs/go-log/v2 v2.5.1
@@ -69,7 +70,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8 // indirect
-	github.com/cosmos/cosmos-sdk v0.46.14 // indirect
 	github.com/cosmos/cosmos-sdk/api v0.1.0 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogoproto v1.4.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -351,4 +351,4 @@ replace (
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.29.0-tm-v0.34.29
 )
 
-replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.0.2-0.20240109213634-1bddfc5ae4fb
+replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.0.2-0.20240109232900-0707fa92070b

--- a/go.sum
+++ b/go.sum
@@ -2102,8 +2102,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rollkit/go-da v0.0.2-0.20240109213634-1bddfc5ae4fb h1:Z2KTpksnwizQ1/uY4owvwdZ52HGz4xuvqTuWDYtlsv8=
-github.com/rollkit/go-da v0.0.2-0.20240109213634-1bddfc5ae4fb/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
+github.com/rollkit/go-da v0.0.2-0.20240109232900-0707fa92070b h1:lAuf/ZRPtrJwBnK3S0OIOj6f7qQXjfVqxdqk5gpjq2o=
+github.com/rollkit/go-da v0.0.2-0.20240109232900-0707fa92070b/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/go.sum
+++ b/go.sum
@@ -2102,8 +2102,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rollkit/go-da v0.0.2-0.20240109232900-0707fa92070b h1:lAuf/ZRPtrJwBnK3S0OIOj6f7qQXjfVqxdqk5gpjq2o=
-github.com/rollkit/go-da v0.0.2-0.20240109232900-0707fa92070b/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
+github.com/rollkit/go-da v0.1.0 h1:FAEMTNF8mTsPuiUgYt2dQSMzw8iYPjiWq7692CS2mbY=
+github.com/rollkit/go-da v0.1.0/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/go.sum
+++ b/go.sum
@@ -2102,8 +2102,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rollkit/go-da v0.0.2-0.20240109212456-5258ae15192c h1:0DT9VU0Jj4njOyYUKNVaQbq+8Oi5yuKiUWJmAB/hqLw=
-github.com/rollkit/go-da v0.0.2-0.20240109212456-5258ae15192c/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
+github.com/rollkit/go-da v0.0.2-0.20240109213634-1bddfc5ae4fb h1:Z2KTpksnwizQ1/uY4owvwdZ52HGz4xuvqTuWDYtlsv8=
+github.com/rollkit/go-da v0.0.2-0.20240109213634-1bddfc5ae4fb/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/go.sum
+++ b/go.sum
@@ -2102,8 +2102,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rollkit/go-da v0.0.0-20231225164956-a3533025ce47 h1:aprTK4O2aqZ/Mb1pqrxH6EdKs331oJEyf5OROpN1o1Q=
-github.com/rollkit/go-da v0.0.0-20231225164956-a3533025ce47/go.mod h1:cy1LA9kCyCJHgszKkTh9hJn816l5Oa87GMA2c1imfqA=
+github.com/rollkit/go-da v0.0.2-0.20240109212456-5258ae15192c h1:0DT9VU0Jj4njOyYUKNVaQbq+8Oi5yuKiUWJmAB/hqLw=
+github.com/rollkit/go-da v0.0.2-0.20240109212456-5258ae15192c/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/specs/src/celestia-da.md
+++ b/specs/src/celestia-da.md
@@ -48,13 +48,13 @@ The implementation calls `blob.CreateCommitments` which does not call any RPC me
 
 Submit submits blobs and returns their ids and proofs.
 
-The implementation calls [blob.Submit] RPC method with `DefaultSubmitOptions` on the Celestia Node API if gasPrice is set to zero.
+The implementation calls [blob.Submit] RPC method with `DefaultSubmitOptions` on the Celestia Node API if `gasPrice` is greater than or equal to zero.
 
 `DefaultSubmitOptions` uses default values for `Fee` and `GasLimit`.
 
-If `gasPrice` is not zero, then it uses `app types` to `EstimateGas` based on the blob sizes and updates `GasLimit` and `Fee` on the `SubmitOptions` accordingly.
+If `gasPrice` is less than zero, then it uses `app types` to `EstimateGas` based on the blob sizes and updates `GasLimit` and `Fee` on the `SubmitOptions` accordingly.
 
-This way the client can default to `DefaultSubmitOptions` by passing in zero `gasPrice` and increase it to prioritise the transaction.
+This way the client increase the `gasPrice`
 
 ### Validate
 

--- a/specs/src/celestia-da.md
+++ b/specs/src/celestia-da.md
@@ -48,9 +48,13 @@ The implementation calls `blob.CreateCommitments` which does not call any RPC me
 
 Submit submits blobs and returns their ids and proofs.
 
-The implementation calls [blob.Submit] RPC method with `DefaultSubmitOptions` on the Celestia Node API.
+The implementation calls [blob.Submit] RPC method with `DefaultSubmitOptions` on the Celestia Node API if gasPrice is set to zero.
 
 `DefaultSubmitOptions` uses default values for `Fee` and `GasLimit`.
+
+If `gasPrice` is not zero, then it uses `app types` to `EstimateGas` based on the blob sizes and updates `GasLimit` and `Fee` on the `SubmitOptions` accordingly.
+
+This way the client can default to `DefaultSubmitOptions` by passing in zero `gasPrice` and increase it to prioritise the transaction.
 
 ### Validate
 

--- a/specs/src/celestia-da.md
+++ b/specs/src/celestia-da.md
@@ -54,7 +54,7 @@ The implementation calls [blob.Submit] RPC method with `DefaultSubmitOptions` on
 
 If `gasPrice` is less than zero, then it uses `app types` to `EstimateGas` based on the blob sizes and updates `GasLimit` and `Fee` on the `SubmitOptions` accordingly.
 
-This way the client increase the `gasPrice`
+This way the client increase the `gasPrice` to increase the fee for the transaction or use the default by passing a negative `gasPrice`.
 
 ### Validate
 


### PR DESCRIPTION
## Overview

This PR upgrades go-da to v0.1.0 (pending release) which has a breaking change: `Submit` now accepts an additional `GasPrice` param which can be set to negative to use default options.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords

Fixes #29 

Depends on:

- https://github.com/rollkit/go-da/pull/31


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced gas price configuration for transaction submissions, enabling prioritization based on gas price.

- **Documentation**
	- Updated Celestia Node API specs to reflect the new gas price parameter in transaction submissions.

- **Tests**
	- Modified existing tests to accommodate the new gas price parameter in the `Submit` function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->