### PR TITLE
cmd: add --da.grpc.gasprice optional flag

### DIFF
--- a/celestia/celestia.go
+++ b/celestia/celestia.go
@@ -85,6 +85,10 @@ func (c *CelestiaDA) Submit(daBlobs []da.Blob, gasPrice float64) ([]da.ID, []da.
 		return nil, nil, err
 	}
 	options := blob.DefaultSubmitOptions()
+	// if gas price was configured globally use that as the default
+	if c.gasPrice >= 0 && gasPrice < 0 {
+		gasPrice = c.gasPrice
+	}
 	if gasPrice >= 0 {
 		blobSizes := make([]uint32, len(blobs))
 		for i, blob := range blobs {

--- a/celestia/celestia.go
+++ b/celestia/celestia.go
@@ -23,14 +23,16 @@ import (
 type CelestiaDA struct {
 	client    *rpc.Client
 	namespace share.Namespace
+	gasPrice  float64
 	ctx       context.Context
 }
 
 // NewCelestiaDA returns an instance of CelestiaDA
-func NewCelestiaDA(client *rpc.Client, namespace share.Namespace, ctx context.Context) *CelestiaDA {
+func NewCelestiaDA(client *rpc.Client, namespace share.Namespace, gasPrice float64, ctx context.Context) *CelestiaDA {
 	return &CelestiaDA{
 		client:    client,
 		namespace: namespace,
+		gasPrice:  gasPrice,
 		ctx:       ctx,
 	}
 }
@@ -95,7 +97,7 @@ func (c *CelestiaDA) Submit(daBlobs []da.Blob, gasPrice float64) ([]da.ID, []da.
 	if err != nil {
 		return nil, nil, err
 	}
-	log.Println("successfully submitted blobs", "height", height)
+	log.Println("successfully submitted blobs", "height", height, "gas", options.GasLimit, "fee", options.Fee)
 	ids := make([]da.ID, len(daBlobs))
 	proofs := make([]da.Proof, len(daBlobs))
 	for i, commitment := range commitments {

--- a/celestia/celestia_test.go
+++ b/celestia/celestia_test.go
@@ -124,7 +124,15 @@ func TestCelestiaDA(t *testing.T) {
 		assert.Equal(t, 1, len(proofs))
 	})
 
-	t.Run("Submit_existing_with_gasprice", func(t *testing.T) {
+	t.Run("Submit_existing_with_gasprice_global", func(t *testing.T) {
+		m.CelestiaDA.gasPrice = 0.01
+		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, -1)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(blobs))
+		assert.Equal(t, 1, len(proofs))
+	})
+
+	t.Run("Submit_existing_with_gasprice_override", func(t *testing.T) {
 		blobs, proofs, err := m.Submit([]Blob{[]byte{0x00, 0x01, 0x02}}, 0.5)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(blobs))

--- a/celestia/celestia_test.go
+++ b/celestia/celestia_test.go
@@ -37,7 +37,7 @@ func setup(t *testing.T) *mockDA {
 	assert.NoError(t, err)
 	namespace, err := share.NewBlobNamespaceV0(ns)
 	assert.NoError(t, err)
-	da := NewCelestiaDA(client, namespace, ctx)
+	da := NewCelestiaDA(client, namespace, -1, ctx)
 	assert.Equal(t, da.client, client)
 
 	return &mockDA{mockService, *da}

--- a/celestia_test.go
+++ b/celestia_test.go
@@ -100,7 +100,7 @@ func (t *TestSuite) TestCelestiaDA() {
 	t.Require().NoError(err)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	da := celestia.NewCelestiaDA(client, ns, ctx)
+	da := celestia.NewCelestiaDA(client, ns, -1, ctx)
 	test.RunDATestSuite(t.T(), da)
 }
 

--- a/cmd/celestia-da/cmd.go
+++ b/cmd/celestia-da/cmd.go
@@ -12,7 +12,7 @@ const (
 	grpcNamespaceFlag = "da.grpc.namespace"
 	grpcListenFlag    = "da.grpc.listen"
 	grpcNetworkFlag   = "da.grpc.network"
-	gasPriceFlag      = "da.gasprice"
+	grpcGasPriceFlag  = "da.grpc.gasprice"
 )
 
 // WithDataAvailabilityService patches the start command to also run the gRPC Data Availability service
@@ -24,7 +24,7 @@ func WithDataAvailabilityService(flags []*pflag.FlagSet) func(*cobra.Command) {
 		grpcFlags.String(grpcNamespaceFlag, "", "celestia namespace to use (hex encoded)")
 		grpcFlags.String(grpcListenFlag, "127.0.0.1:0", "gRPC service listen address")
 		grpcFlags.String(grpcNetworkFlag, "tcp", "gRPC service listen network type must be \"tcp\", \"tcp4\", \"tcp6\", \"unix\" or \"unixpacket\"")
-		grpcFlags.Float64(gasPriceFlag, -1, "gas price for estimating fee (utia/gas) default: -1 for default fees")
+		grpcFlags.Float64(grpcGasPriceFlag, -1, "gas price for estimating fee (utia/gas) default: -1 for default fees")
 
 		fset := append(flags, grpcFlags)
 
@@ -43,7 +43,7 @@ func WithDataAvailabilityService(flags []*pflag.FlagSet) func(*cobra.Command) {
 			nsString, _ := cmd.Flags().GetString(grpcNamespaceFlag)
 			listenAddress, _ := cmd.Flags().GetString(grpcListenFlag)
 			listenNetwork, _ := cmd.Flags().GetString(grpcNetworkFlag)
-			gasPrice, _ := cmd.Flags().GetFloat64(gasPriceFlag)
+			gasPrice, _ := cmd.Flags().GetFloat64(grpcGasPriceFlag)
 
 			if rpcToken == "" {
 				token, err := authToken(cmdnode.StorePath(c.Context()))

--- a/cmd/celestia-da/cmd.go
+++ b/cmd/celestia-da/cmd.go
@@ -12,6 +12,7 @@ const (
 	grpcNamespaceFlag = "da.grpc.namespace"
 	grpcListenFlag    = "da.grpc.listen"
 	grpcNetworkFlag   = "da.grpc.network"
+	gasPriceFlag      = "da.gasprice"
 )
 
 // WithDataAvailabilityService patches the start command to also run the gRPC Data Availability service
@@ -23,6 +24,7 @@ func WithDataAvailabilityService(flags []*pflag.FlagSet) func(*cobra.Command) {
 		grpcFlags.String(grpcNamespaceFlag, "", "celestia namespace to use (hex encoded)")
 		grpcFlags.String(grpcListenFlag, "127.0.0.1:0", "gRPC service listen address")
 		grpcFlags.String(grpcNetworkFlag, "tcp", "gRPC service listen network type must be \"tcp\", \"tcp4\", \"tcp6\", \"unix\" or \"unixpacket\"")
+		grpcFlags.Float64(gasPriceFlag, -1, "gas price for estimating fee (utia/gas) default: -1 for default fees")
 
 		fset := append(flags, grpcFlags)
 
@@ -41,6 +43,7 @@ func WithDataAvailabilityService(flags []*pflag.FlagSet) func(*cobra.Command) {
 			nsString, _ := cmd.Flags().GetString(grpcNamespaceFlag)
 			listenAddress, _ := cmd.Flags().GetString(grpcListenFlag)
 			listenNetwork, _ := cmd.Flags().GetString(grpcNetworkFlag)
+			gasPrice, _ := cmd.Flags().GetFloat64(gasPriceFlag)
 
 			if rpcToken == "" {
 				token, err := authToken(cmdnode.StorePath(c.Context()))
@@ -51,7 +54,7 @@ func WithDataAvailabilityService(flags []*pflag.FlagSet) func(*cobra.Command) {
 			}
 
 			// serve the gRPC service in a goroutine
-			go serve(cmd.Context(), rpcAddress, rpcToken, listenAddress, listenNetwork, nsString)
+			go serve(cmd.Context(), rpcAddress, rpcToken, listenAddress, listenNetwork, nsString, gasPrice)
 		}
 
 		c.PreRun = preRun

--- a/cmd/celestia-da/server.go
+++ b/cmd/celestia-da/server.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rollkit/go-da/proxy"
 )
 
-func serve(ctx context.Context, rpcAddress, rpcToken, listenAddress, listenNetwork, nsString string) {
+func serve(ctx context.Context, rpcAddress, rpcToken, listenAddress, listenNetwork, nsString string, gasPrice float64) {
 	client, err := rpc.NewClient(ctx, rpcAddress, rpcToken)
 	if err != nil {
 		log.Fatalln("failed to create celestia-node RPC client:", err)
@@ -32,7 +32,7 @@ func serve(ctx context.Context, rpcAddress, rpcToken, listenAddress, listenNetwo
 		log.Fatalln("invalid namespace:", err)
 	}
 
-	da := celestia.NewCelestiaDA(client, namespace, ctx)
+	da := celestia.NewCelestiaDA(client, namespace, gasPrice, ctx)
 	// TODO(tzdybal): add configuration options for encryption
 	srv := proxy.NewServer(da, grpc.Creds(insecure.NewCredentials()))
 


### PR DESCRIPTION
## Overview

This PR adds a new cli flag `--da.grpc.gasprice` that allows the service to configure a global gas price for all blob transactions. It defaults to `-1` to use the default fees.

Note that each transaction can override the global gas price by passing in a non-negative gas price to `Submit`.

Fixes #47 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new gas price configuration option for data availability submissions.

- **Bug Fixes**
  - Corrected the initialization of data availability components to properly handle the new gas price parameter.

- **Refactor**
  - Updated internal test cases to align with the new gas price functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->