### PR TITLE
ci: bump local-celestia-devnet to v0.12.6

### DIFF
--- a/celestia_test.go
+++ b/celestia_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rollkit/go-da/test"
 )
 
-const localCelestiaDevnetImageVersion = "v0.12.5"
+const localCelestiaDevnetImageVersion = "v0.12.6"
 
 type TestSuite struct {
 	suite.Suite


### PR DESCRIPTION
## Overview

This PR updates local-celestia-devnet to v0.12.6

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the local Celestia development network image to version 0.12.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->